### PR TITLE
Allow this library to be included in the Windows builds of other components

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg(target_family = "unix")]
 //! A wrapper around the standard [`std::env`](https://doc.rust-lang.org/std/env/index.html)
 //! functions that allows for a test double to be injected during testing.
 //!


### PR DESCRIPTION
This change is not a full-fledged support for Windows. We are still marking the library as Linux only. However, it's a first step toward it to allow this library to be included in Windows builds.

There are several known limitations that need to be addressed:
- Several tests (around invalid Unicode) are Linux-specific
- The behavior around case sensitivity of Windows env variables needs to be investigated and added to the tests