### PR TITLE
Use 2024 edition of Rust.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "env_wrapper"
 authors = ["Will-Low <26700668+Will-Low@users.noreply.github.com>"]
-version = "0.1.1"
-edition = "2021"
+version = "0.2.0"
+edition = "2024"
 description = "A wrapper around std::env to facilitate testing"
 readme = "README.md"
 homepage = "https://aembit.io/"
@@ -19,7 +19,8 @@ exclude = [
 maintenance = { status = "passively-maintained"}
 
 [dependencies]
+regex = "> 1.8.0"
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = "0.9.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,9 @@ use std::{
     ffi::{OsStr, OsString},
 };
 
-/// Represents a process's environment.
+/// Represents a process's environment. It should be considered `unsafe` despite not being marked
+/// `unsafe`. This is because the `RealEnvironment` impl needs to call `unsafe` methods but the
+/// `FakeEnvironment` does not.
 pub trait Environment {
     /// Set an environment variable.
     fn set_var(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>);
@@ -133,7 +135,7 @@ impl Environment for RealEnvironment {
     /// > This function may panic if `key` is empty, contains an ASCII equals sign `'='`
     /// > or the NUL character `'\0'`, or when `value` contains the NUL character.
     fn set_var(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
-        env::set_var(key, value)
+        unsafe { env::set_var(key, value) }
     }
 
     /// From [`std::env::var`](https://doc.rust-lang.org/std/env/fn.var.html):
@@ -193,7 +195,7 @@ impl Environment for RealEnvironment {
     /// > `'='` or the NUL character `'\0'`, or when the value contains the NUL
     /// > character.
     fn remove_var(&mut self, key: impl AsRef<OsStr>) {
-        env::remove_var(key)
+        unsafe { env::remove_var(key) }
     }
 }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,11 +1,12 @@
 #![cfg(test)]
 
-use rand::{distributions::Uniform, Rng};
+use rand::{distr::Uniform, Rng};
 
 /// Random 12-character uppercase text.
 pub fn random_upper() -> String {
-    let mut rng = rand::thread_rng();
-    let upper = Uniform::from(b'A'..=b'Z');
+    let mut rng = rand::rng();
+    let upper = Uniform::try_from(b'A'..=b'Z')
+        .expect("Failure to construct distribution over ASCII letters.");
     (0..11).map(|_| rng.sample(upper) as char).collect()
 }
 


### PR DESCRIPTION
This adopts the 2024 edition of Rust and updates the `rand` dependency.